### PR TITLE
JSX failed to create a temporary file in JSX.execNodeJS() on Windows.

### DIFF
--- a/bin/jsx
+++ b/bin/jsx
@@ -109,7 +109,7 @@ var JSX = Class.extend({
 
 	$execNodeJS: function (script, args) {
 		// XXX: node.js (0.6.x) doesn't suport "--" option :(
-		var tmpdir = process.env.TMPDIR || "/tmp";
+		var tmpdir = process.env.TMPDIR || process.env.TMP || "/tmp";
 		var tmpfile = Util.format("%1/jsx.%2.%3.js", [
 			tmpdir, process.pid.toString(), Date.now().toString(16)
 		]);


### PR DESCRIPTION
Windows doesn't have process.env.TMPDIR.
Therefore, JSX failed to create a temporary file in JSX.execNodeJS() on Windows with the error message "Error: ENOENT, no such file or directory 'C:\tmp\jsx.28228.137a1cb2717.js' 

To fix this bug, I added "|| process.env.TMP" to "var tmpdir."
