### PR TITLE
fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   "bin" : {
       "jsx" : "./bin/jsx"
   },
+  "directories": {
+    "bin": "./bin",
+    "lib": "./lib"
+  },
   "devDependencies": {
       "browserbuild": "*",
       "source-map": "*"


### PR DESCRIPTION
related issue #1, `npm install .` does not work on windows. It seems that need to add `directories` key in package.json .
