### PR TITLE
fix static closure.

### DIFF
--- a/src/jsemitter.js
+++ b/src/jsemitter.js
@@ -1196,6 +1196,7 @@ var _PropertyExpressionEmitter = exports._PropertyExpressionEmitter = _UnaryExpr
 		this._emitter._getExpressionEmitterFor(expr.getExpr()).emit(this._getPrecedence());
 		// mangle the name if necessary
 		if (exprType instanceof FunctionType && ! exprType.isAssignable()
+			&& (expr.getHolderType().getClassDef() instanceof InstantiatedClassDefinition)
 			&& (expr.getHolderType().getClassDef().flags() & ClassDefinition.IS_NATIVE) == 0) {
 			if (expr.getExpr()._classDefType instanceof ClassDefType) {
 				// do not use "." notation for static functions, but use class$name

--- a/t/run/142.static-closure.jsx
+++ b/t/run/142.static-closure.jsx
@@ -1,0 +1,11 @@
+/*EXPECTED
+hello
+*/
+class Test {
+	static var f = function() : string {
+		return "hello";
+	};
+	static function run() : void {
+		log Test.f();
+	}
+}


### PR DESCRIPTION
Hi, seems to be an error when using static closure.

``` java
class _Main {
    static var f = function() : string {
        return "hello";
    };
    static function main(args :string[]) : void {
        log _Main.f();
    }
}
```
