### PR TITLE
support str[num] syntax: syntax sugar for str.charAt(num)

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -1325,6 +1325,8 @@ var ArrayExpression = exports.ArrayExpression = BinaryExpression.extend({
 		} else if (expr1Type.equals(Type.variantType)) {
 			return this._analyzeApplicationOnVariant(context);
 			return true;
+		} else if (expr1Type.equals(Type.stringType)) {
+			return this._analyzeApplicationOnString(context);
 		}
 		context.errors.push(new CompileError(this._token, "cannot apply []; the operator is only applicable against an array or an variant"));
 		return false;
@@ -1363,6 +1365,16 @@ var ArrayExpression = exports.ArrayExpression = BinaryExpression.extend({
 			return false;
 		}
 		this._type = Type.variantType;
+		return true;
+	},
+
+	_analyzeApplicationOnString: function (context) {
+		var expr2Type = this._expr2.getType().resolveIfMayBeUndefined();
+		if (! (expr2Type.isConvertibleTo(Type.numberType))) {
+			context.errors.push(new CompileError("the argument of string[] should be a number"));
+			return false;
+		}
+		this._type = Type.stringType;
 		return true;
 	},
 

--- a/src/jsemitter.js
+++ b/src/jsemitter.js
@@ -1314,10 +1314,18 @@ var _ArrayExpressionEmitter = exports._ArrayExpressionEmitter = _OperatorExpress
 	},
 
 	_emit: function () {
-		this._emitter._getExpressionEmitterFor(this._expr.getFirstExpr()).emit(_ArrayExpressionEmitter._operatorPrecedence);
-		this._emitter._emit("[", this._expr.getToken());
-		this._emitter._getExpressionEmitterFor(this._expr.getSecondExpr()).emit(0);
-		this._emitter._emit("]", null);
+		var type = this._expr.getFirstExpr().getType().resolveIfMayBeUndefined();
+		if(type.equals(Type.stringType)) {
+			this._emitter._getExpressionEmitterFor(this._expr.getFirstExpr()).emit(_ArrayExpressionEmitter._operatorPrecedence);
+			this._emitter._emit(".charAt(", this._expr.getToken());
+			this._emitter._getExpressionEmitterFor(this._expr.getSecondExpr()).emit(0);
+			this._emitter._emit(")", null);
+		} else {
+			this._emitter._getExpressionEmitterFor(this._expr.getFirstExpr()).emit(_ArrayExpressionEmitter._operatorPrecedence);
+			this._emitter._emit("[", this._expr.getToken());
+			this._emitter._getExpressionEmitterFor(this._expr.getSecondExpr()).emit(0);
+			this._emitter._emit("]", null);
+		}
 	},
 
 	_getPrecedence: function () {

--- a/t/run/142.charAt.jsx
+++ b/t/run/142.charAt.jsx
@@ -1,0 +1,8 @@
+/*EXPECTED
+a
+*/
+class Test {
+	static function run() : void {
+		log "abc"[0];
+	}
+}


### PR DESCRIPTION
Add string[number] syntax. It is converted to string.charAt(number).

Although many browsers support string[number] syntax, IE does not support it. By adding this syntax sugar, we could use its syntax in portable way.
