### PR TITLE
support : string compare

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -1474,13 +1474,29 @@ var BinaryNumberExpression = exports.BinaryNumberExpression = BinaryExpression.e
 	analyze: function (context, parentExpr) {
 		if (! this._analyze(context))
 			return false;
-		var expr1Type = this._expr1.getType().resolveIfMayBeUndefined();
-		if (! this.assertIsConvertibleTo(context, this._expr1, Type.numberType, true))
+		switch (this._token.getValue()) {
+		case "<":
+		case "<=":
+		case ">":
+		case ">=":
+			var expr1Type = this._expr1.getType().resolveIfMayBeUndefined();
+			if (expr1Type.isConvertibleTo(Type.numberType)) {
+			  return this.assertIsConvertibleTo(context, this._expr2, Type.numberType, true);
+			}
+			if(expr1Type.isConvertibleTo(Type.stringType)) {
+			  return this.assertIsConvertibleTo(context, this._expr2, Type.stringType, true);
+			}
+			context.errors.push(new CompileError(this._token, "cannot apply operator '" + this._token.getValue() + "' to type '" + expr1Type.toString() + "'"));
 			return false;
-		var expr2Type = this._expr2.getType().resolveIfMayBeUndefined();
-		if (! this.assertIsConvertibleTo(context, this._expr2, Type.numberType, true))
-			return false;
-		return true;
+		default:
+			var expr1Type = this._expr1.getType().resolveIfMayBeUndefined();
+			if (! this.assertIsConvertibleTo(context, this._expr1, Type.numberType, true))
+				return false;
+			var expr2Type = this._expr2.getType().resolveIfMayBeUndefined();
+			if (! this.assertIsConvertibleTo(context, this._expr2, Type.numberType, true))
+				return false;
+			return true;
+		}
 	},
 
 	getType: function () {

--- a/t/compile_error/130.compare-other-type.jsx
+++ b/t/compile_error/130.compare-other-type.jsx
@@ -1,0 +1,5 @@
+class Test {
+	static function run() : void {
+		"answer" < 42;
+	}
+}

--- a/t/run/150.string-compare.jsx
+++ b/t/run/150.string-compare.jsx
@@ -1,0 +1,23 @@
+/*EXPECTED
+true
+false
+true
+false
+false
+true
+false
+true
+*/
+
+class Test {
+	static function run() : void {
+		log "a" < "b";
+		log "b" < "a";
+		log "a" <= "b";
+		log "b" <= "a";
+		log "a" > "b";
+		log "b" > "a";
+		log "a" >= "b";
+		log "b" >= "a";
+	}
+}


### PR DESCRIPTION
Support string comparasion by ordinary operator(<, <=, >, >=).

Because many JS engines support this syntax, this syntax make script-porting easy.

And more, ES5 define string-compare algorithm at "11.8.5 The Abstract Relational Comparison Algorithm", so JSX does not lose a compatibility by this extension.
