### PR TITLE
Add local function declaration

### DIFF
--- a/t/run/168.local-function-declaration.jsx
+++ b/t/run/168.local-function-declaration.jsx
@@ -1,0 +1,38 @@
+/*EXPECTED
+3
+2
+1
+0
+bang
+3
+2
+1
+0
+bang
+*/
+
+class Test {
+	static function run() : void {
+		function bang1(n : number) : string {
+			log n;
+			if ( n == 0 ) {
+				return "bang";
+			} else {
+				return bang1(n-1);
+			}
+		}
+
+		// function expression still alive
+		var bang2 = function(n : number) : string {
+			log n;
+			if ( n == 0 ) {
+				return "bang";
+			} else {
+				return bang2(n-1);
+			}
+		};
+
+		log bang1(3);
+		log bang2(3);
+	}
+}


### PR DESCRIPTION
I add a local function declaration.

```
function someMethod() {     
  function inc(x : number) : number {
    return x + 1;
  }

  log inc(1); // -> 2
}
```

Off course, this is a only syntax sugar for <code>var inc = funciton(x:number) : number { ... }</code>.
But this make it easy to port Javascript library to JSX.
