### PR TITLE
fix error handling for an argument

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -1375,7 +1375,7 @@ var ArrayExpression = exports.ArrayExpression = BinaryExpression.extend({
 	_analyzeApplicationOnVariant: function (context) {
 		var expr2Type = this._expr2.getType().resolveIfNullable();
 		if (! (expr2Type.equals(Type.stringType) || expr2Type.isConvertibleTo(Type.numberType))) {
-			context.errors.push(new CompileError("the argument of variant[] should be a string or a number"));
+			context.errors.push(new CompileError(this._token, "the argument of variant[] should be a string or a number"));
 			return false;
 		}
 		this._type = Type.variantType;

--- a/t/compile_error/143.variant-access.jsx
+++ b/t/compile_error/143.variant-access.jsx
@@ -1,0 +1,8 @@
+class Test {
+  function main() : void {
+    var key : variant = null;
+    var obj : variant = null;
+    obj[key]; 
+  }
+}
+


### PR DESCRIPTION
Following code crush a compiler(3d480fc84e59e7d61314f92d61dcde34ca30ac4c).

```
class Test {
  function main() : void {
    var key : variant = null;
    var obj : variant = null;
    obj[key];
  }
}
```
## 

```
fatal error while compiling statement at file /Users/mzp/foo.jsx, line 5

Error: Unrecognized arguments for CompileError: the argument of variant[] should be a string or a number
    at [object Object].<anonymous> (/Users/mzp/workspaces/JSX/src/util.js:269:10)
    at new <anonymous> (/Users/mzp/workspaces/JSX/src/util.js:303:38)
    at [object Object]._analyzeApplicationOnVariant (/Users/mzp/workspaces/JSX/src/expression.js:1378:24)
    at [object Object].analyze (/Users/mzp/workspaces/JSX/src/expression.js:1343:16)
    at [object Object]._analyzeExpr (/Users/mzp/workspaces/JSX/src/statement.js:72:16)
    at [object Object].doAnalyze (/Users/mzp/workspaces/JSX/src/statement.js:184:8)
    at [object Object].analyze (/Users/mzp/workspaces/JSX/src/statement.js:45:16)
    at [object Object].analyze (/Users/mzp/workspaces/JSX/src/classdef.js:954:31)
    at [object Object]._analyzeMemberFunctions (/Users/mzp/workspaces/JSX/src/classdef.js:499:12)
    at [object Object].analyze (/Users/mzp/workspaces/JSX/src/classdef.js:351:8)
```
