### PR TITLE
fix array-length optimizer bug

### DIFF
--- a/src/optimizer.js
+++ b/src/optimizer.js
@@ -1401,7 +1401,7 @@ var _ArrayLengthOptimizeCommand = exports._ArrayLengthOptimizeCommand = _Functio
 				local = expr.getExpr().getLocal();
 				return false;
 			}
-			return expr.forEachExpression(onExpr);
+			return expr.forEachExpression(onExpr.bind(this));
 		}.bind(this));
 		return local;
 	},

--- a/t/optimize/027.array-length.jsx
+++ b/t/optimize/027.array-length.jsx
@@ -8,7 +8,7 @@ class Test {
 	static function run() : void {
 		var a = [ 1, 2, 3, 4 ];
 		var sum = 0;
-		for (var i = 0; i < a.length; ++i) {
+		for (var i = 0; i < 1*a.length; ++i) {
 			sum += a[i];
 		}
 		log sum;


### PR DESCRIPTION
Following code crush compiler(a6a679de9dfb34e179a15b534119889ad49841a1) with array-length optimizer.

```
class _Test {
    function main() : void {
        var xs = [] : number[];
        for(var i = 0; i < xs.length*1; i += 1) {}
    }
 }
```

---

```
$ jsx --optimize array-length foo.jsx
optimizer 'undefined' died unexpectedly, dumping the logs
starting optimizer: array-length
[array-length] starting optimization of Math.abs(:number)
[array-length] finished optimization of Math.abs(:number)
[array-length] starting optimization of Math.max(:number, :number)
[array-length] finished optimization of Math.max(:number, :number)
[array-length] starting optimization of Math.min(:number, :number)
[array-length] finished optimization of Math.min(:number, :number)
[array-length] starting optimization of Array.<string>#forEach(:function ( : Nullable.<string>) : void)
[array-length] finished optimization of Array.<string>#forEach(:function ( : Nullable.<string>) : void)
[array-length] starting optimization of _Test#main()

/Users/mzp/workspaces/JSX/src/optimizer.js:161
                                throw e;
          ^
TypeError: Object #<Object> has no method '_typeIsArray'
    at onExpr (/Users/mzp/workspaces/JSX/src/optimizer.js:1400:13)
    at [object Object].forEachExpression (/Users/mzp/workspaces/JSX/src/expression.js:1270:9)
    at [object Object].onExpr (/Users/mzp/workspaces/JSX/src/optimizer.js:1404:16)
    at [object Object].forEachExpression (/Users/mzp/workspaces/JSX/src/expression.js:1272:9)
    at [object Object]._hasLengthExprOfLocalArray (/Users/mzp/workspaces/JSX/src/optimizer.js:1396:8)
    at [object Object].onStatement (/Users/mzp/workspaces/JSX/src/optimizer.js:1346:27)
    at Function.forEachStatement (/Users/mzp/workspaces/JSX/src/util.js:121:11)
    at [object Object].forEachStatement (/Users/mzp/workspaces/JSX/src/classdef.js:1179:15)
    at [object Object].optimizeFunction (/Users/mzp/workspaces/JSX/src/optimizer.js:1343:11)
    at [object Object].<anonymous> (/Users/mzp/workspaces/JSX/src/optimizer.js:246:9)
```

Note: This bug is caused by forgetting add `bind(this)` for recursion step. Some related bug may be contained in optimizer.js.
