### PR TITLE
Fixes missing null check on MemberFunctionDefinition affecting parse mode.

### DIFF
--- a/src/classdef.js
+++ b/src/classdef.js
@@ -949,7 +949,7 @@ var MemberFunctionDefinition = exports.MemberFunctionDefinition = MemberDefiniti
 			"token"      : this._token.serialize(),
 			"nameToken"  : Util.serializeNullable(this._nameToken),
 			"flags"      : this.flags(),
-			"returnType" : this._returnType.serialize(),
+			"returnType" : (this._returnType) ? this._returnType.serialize() : null,
 			"args"       : Util.serializeArray(this._args),
 			"locals"     : Util.serializeArray(this._locals),
 			"statements" : Util.serializeArray(this._statements)


### PR DESCRIPTION
I'm not sure of the proper way to add a test for this. However, it can be reproduced by running:
bin/jsx --mode parse t/run/158.deduct-closure-type-in-super-statement.jsx
