### PR TITLE
Enhanced type inference of conditional expression

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -1764,26 +1764,9 @@ var ConditionalExpression = exports.ConditionalExpression = OperatorExpression.e
 			typeIfTrue = this._condExpr.getType();
 		}
 		var typeIfFalse = this._ifFalseExpr.getType();
-		if (typeIfTrue.equals(typeIfFalse)) {
-			// ok
-			this._type = typeIfTrue;
-		} else if (
-			(typeIfTrue instanceof NullableType) == (typeIfFalse instanceof NullableType)
-			&& Type.isIntegerOrNumber(typeIfTrue.resolveIfNullable())
-			&& Type.isIntegerOrNumber(typeIfFalse.resolveIfNullable())) {
-			// special case to handle number == integer
-			this._type = typeIfTrue instanceof NullableType ? new NullableType(Type.numberType) : Type.numberType;
-		} else if (this._ifTrueExpr == null
-			&& (typeIfTrue.resolveIfNullable().equals(typeIfFalse)
-				|| (Type.isIntegerOrNumber(typeIfTrue.resolveIfNullable()) && Type.isIntegerOrNumber(typeIfFalse)))) {
-			// on ?: expr (wo. true expr), left hand can be maybeundefined.<right>
-			this._type = typeIfFalse;
-		} else if (this._ifTrueExpr != null && typeIfTrue.equals(Type.nullType) && typeIfFalse instanceof ObjectType) {
-			this._type = typeIfFalse;
-		} else if (this._ifTrueExpr != null && typeIfTrue instanceof ObjectType && typeIfFalse.equals(Type.nullType)) {
-			this._type = typeIfTrue;
-		} else {
-			context.errors.push(new CompileError(this._token, "returned types should be the same for operator ?: but got '" + typeIfTrue.toString() + "' and '" + typeIfFalse.toString() + "'"));
+		this._type = Type.calcLeastCommonAncestor(typeIfTrue, typeIfFalse);
+		if (this._type == null) {
+			context.errors.push(new CompileError(this._token, "could not get the join type of '" + typeIfTrue.toString() + "' and '" + typeIfFalse.toString() + "'"));
 			return false;
 		}
 		return true;


### PR DESCRIPTION
I changed the behavior of conditional expression like below:

```
class A {}
class B extends A {}
class C extends A {}

interface I {}
class X implements I {}
class Y implements I {}
class Z extends Y {}

class _Main {
    static function main(args : string[]) : void {
        var variant_value = 123 as variant;

        var a = (true)? 1 : 1.0; // number
        var b = (true)? "asdf" : [ "a", "b"][0]; // Nullable.<string>
        var c = (true)? variant_value : 1;   // variant
        var d = (true)? new A : new B;       // A
        var e = (true)? new A : null;        // A
        var f = (true)? 1 : null;        // Nullable.<number>
        var g = (true)? "a" : null;      // Nullable.<string>
        var h = (true)? new B : new C;       // A
        var i = (true)? new X : new Y;       // I
        var j = (true)? new X : new Z;       // I
        var k = (true)? new A : new X;       // Object

        // for now avoids returning variant type as a join of a primitive and an object.
        // var l = (true)? 1 : new A;        // error

        var m = (true)? function (a : A) : X { return new X; } : function (a : A) : X { return new X; }; // (A) -> X

        // calculation of the joins of function types is not supported (for now)
        // var n = (true)? function (a : A) : Y { return new Y; } : function (b : B) : X { return new X; }; // (B) -> X
    }
}
```
