### PR TITLE
add strict type check mode

### DIFF
--- a/bin/jsx
+++ b/bin/jsx
@@ -428,6 +428,13 @@ var JSX = Class.extend({
 							};
 						}(mode));
 						break NEXTOPT;
+					case "strict-type-check":
+						tasks.push(function (mode) {
+							return function () {
+								emitter.setEnableStrictRunTimeTypeCheck(mode);
+							};
+						}(mode));
+						break NEXTOPT;
 					default:
 						break;
 					}


### PR DESCRIPTION
This is a patch to add strict type check mode to JSX.

```
class A {}
class B {}

class _Main {
    static function main(args : string[]) : void {
        var x : variant = new B;
        x as A;
    }
}
```

With this patch, the above code is compiled to below

```
_Main.main$AS = function (args) {
    /** @type {*} */
    var x;
    x = new B$();
    (function (o) {
        if (! (o instanceof A)) {
            debugger;
            throw new Error("[hoge.jsx:7] detected invalid cast, value is not of specified type");
        }
        return o;
    }(x));
};
```

Current JSX compiler compiles a cast expression (a.k.a. as expression) to a conditional expression which is evaluated to the value itself when the instanceof expression is successfully done and otherwise evaluated to null. In this way of treating as expressions, the compiled output code runs faster than in the case of inserting assertions into every single of 'instanceof' statements. However, returning only null and throwing no error sometimes makes it more difficult to debug the code. When debugging, invoking the debugger and throwing a error is an essential feature.

In this patch, the new command line option '--enable-strict-type-check' is introduced. Actually I wanted to use '--enable-type-check' option to switch this type checking feature, but I couldn't make it out if it is ok to change the meaning of existing flag.
By the way, why doesn't the 'type-check' flag switch the compiled result of as expressions? It looks ok to stop guarding the expression with instanceof and uncover the value when type-check mode is disabled like below:

source:

```
x as T;
```

--enable-type-check:

```
(function (o) {
  if (! (o instanceof T)) {
    debugger;
    throw new Error();
  }
  return o;
})(x);
```

--disable-type-check:

```
x
```

Users can check if x is an instanceof T or not themselves so I think there is no problem with treating invalid casts as implementation-dependent.
