### PR TITLE
node.js library: add encoding option and add paramater type Buffer

### DIFF
--- a/lib/js/js/nodejs.jsx
+++ b/lib/js/js/nodejs.jsx
@@ -221,10 +221,13 @@ native __fake__ class _fs {
 
 	function readSync(fd : int, buffer : Buffer, offset : int, length : int) : int;
 	function readSync(fd : int, buffer : Buffer, offset : int, length : int, position : int) : int;
-	function readFileSync(filename : string) : string;
+	function readFileSync(filename : string) : Buffer;
+	function readFileSync(filename : string, encoding : string) : string;
 
 	function writeSync(fd : int, buffer : Buffer, offset : int, length : int, position : int) : int;
+	function writeFileSync(filename : string, data : Buffer) : void;
 	function writeFileSync(filename : string, data : string) : void;
+	function writeFileSync(filename : string, data : string, encoding : string) : void;
 
 	function watch(filename : string, listener : function(event:string,filename:Nullable.<string>):void) : FSWatcher;
 	function watch(filename : string, options : Map.<variant>, listener : function(event:string,filename:Nullable.<string>):void) : FSWatcher;


### PR DESCRIPTION
Fix readFileSync and writeFileSync parameters / return types to match node.js API.

node.jsのAPIに合わせて、引数のタイプ・返り値を修正しました。

http://nodejs.org/api/fs.html#fs_fs_readfilesync_filename_encoding
