### PR TITLE
set binmode to avoid 'Wide character in print' warning

### DIFF
--- a/tool/jsx.pl
+++ b/tool/jsx.pl
@@ -91,6 +91,7 @@ package App::jsx;
             File::Path::mkpath(File::Basename::dirname($file));
         }
         open my($fh), ">", $file or Carp::confess("cannot open file '$file' for writing: $!");
+        binmode $fh, ":utf8";
         print $fh $content;
         close $fh or Carp::confess("cannot close file '$file': $!");
         return;
@@ -250,6 +251,8 @@ package App::jsx;
             return system(prepare_run_command($c->{run}));
         }
         else {
+            binmode STDOUT, ":utf8";
+            binmode STDERR, ":utf8";
             print STDOUT $c->{stdout};
             print STDERR $c->{stderr};
             return $c->{statusCode};


### PR DESCRIPTION
I received 'Wide character in print at ...' warnings, and set binmode to avoid them.

For your reference, my environment is as below:

```
$ perlbug -d

---
Flags:
    category=core
    severity=low

---
Site configuration information for perl 5.17.6:

Configured by ${USER} at Wed Dec 19 16:22:33 JST 2012.

Summary of my perl5 (revision 5 version 17 subversion 6) configuration:

  Platform:
    osname=linux, osvers=2.6.18-308.el5, archname=x86_64-linux
    uname='linux ${HOSTNAME} 2.6.18-308.el5 #1 smp tue feb 21 20:06:06 est 2012 x86_64 x86_64 x86_64 gnulinux '
    config_args='-de -Dprefix=${HOME}/perl5/perlbrew/perls/perl-5.17.6 -Dusedevel -Aeval:scriptdir=${HOME}/perl5/perlbrew/perls/perl-5.17.6/bin'
    hint=recommended, useposix=true, d_sigaction=define
    useithreads=undef, usemultiplicity=undef
    useperlio=define, d_sfio=undef, uselargefiles=define, usesocks=undef
    use64bitint=define, use64bitall=define, uselongdouble=undef
    usemymalloc=n, bincompat5005=undef
  Compiler:
    cc='cc', ccflags ='-fno-strict-aliasing -pipe -fstack-protector -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64',
    optimize='-O2',
    cppflags='-fno-strict-aliasing -pipe -fstack-protector -I/usr/local/include'
    ccversion='', gccversion='4.1.2 20080704 (Red Hat 4.1.2-52)', gccosandvers=''
    intsize=4, longsize=8, ptrsize=8, doublesize=8, byteorder=12345678
    d_longlong=define, longlongsize=8, d_longdbl=define, longdblsize=16
    ivtype='long', ivsize=8, nvtype='double', nvsize=8, Off_t='off_t', lseeksize=8
    alignbytes=8, prototype=define
  Linker and Libraries:
    ld='cc', ldflags =' -fstack-protector -L/usr/local/lib'
    libpth=/usr/local/lib /lib /usr/lib /lib64 /usr/lib64 /usr/local/lib64
    libs=-lnsl -ldl -lm -lcrypt -lutil -lc
    perllibs=-lnsl -ldl -lm -lcrypt -lutil -lc
    libc=/lib/libc-2.5.so, so=so, useshrplib=false, libperl=libperl.a
    gnulibc_version='2.5'
  Dynamic Linking:
    dlsrc=dl_dlopen.xs, dlext=so, d_dlsymun=undef, ccdlflags='-Wl,-E'
    cccdlflags='-fPIC', lddlflags='-shared -O2 -L/usr/local/lib -fstack-protector'

Locally applied patches:


---
@INC for perl 5.17.6:
    ${HOME}/perl5/perlbrew/perls/perl-5.17.6/lib/site_perl/5.17.6/x86_64-linux
    ${HOME}/perl5/perlbrew/perls/perl-5.17.6/lib/site_perl/5.17.6
    ${HOME}/perl5/perlbrew/perls/perl-5.17.6/lib/5.17.6/x86_64-linux
    ${HOME}/perl5/perlbrew/perls/perl-5.17.6/lib/5.17.6
    .

---
Environment for perl 5.17.6:
    HOME=${HOME}
    LANG=ja_JP.UTF-8
    LANGUAGE (unset)
    LD_LIBRARY_PATH (unset)
    LOGDIR (unset)
    PATH=${HOME}/local/bin:${HOME}/perl5/perlbrew/bin:${HOME}/perl5/perlbrew/perls/perl-5.17.6/bin:/usr/local/bin:/bin:/usr/bin
    PERLBREW_BASHRC_VERSION=0.58
    PERLBREW_HOME=${HOME}/.perlbrew
    PERLBREW_MANPATH=${HOME}/perl5/perlbrew/perls/perl-5.17.6/man
    PERLBREW_PATH=${HOME}/perl5/perlbrew/bin:${HOME}/perl5/perlbrew/perls/perl-5.17.6/bin
    PERLBREW_PERL=perl-5.17.6
    PERLBREW_ROOT=${HOME}/perl5/perlbrew
    PERLBREW_VERSION=0.58
    PERL_BADLANG (unset)
    SHELL=/bin/bash
```
