### PR TITLE
add native ("...") class syntax to bind native class (#152)

### DIFF
--- a/src/classdef.jsx
+++ b/src/classdef.jsx
@@ -80,6 +80,8 @@ class ClassDefinition implements Stashable {
 	var _baseClassDef  : ClassDefinition = null;
 	var _outerClassDef : ClassDefinition = null;
 
+	var _nativeSource : Token = null;
+
 	function constructor (token : Token, className : string, flags : number, extendType : ParsedObjectType, implementTypes : ParsedObjectType[], members : MemberDefinition[], inners : ClassDefinition[], templateInners : TemplateClassDefinition[], objectTypesUsed : ParsedObjectType[], docComment : DocComment) {
 		this._parser = null;
 		this._token = token;
@@ -121,6 +123,14 @@ class ClassDefinition implements Stashable {
 
 	function setParser (parser : Parser) : void {
 		this._parser = parser;
+	}
+
+	function getNativeSource () : Token {
+		return this._nativeSource;
+	}
+
+	function setNativeSource (nativeSource : Token) : void {
+		this._nativeSource = nativeSource;
 	}
 
 	function getToken () : Token {

--- a/src/jsemitter.jsx
+++ b/src/jsemitter.jsx
@@ -3060,6 +3060,11 @@ class JavaScriptEmitter implements Emitter {
 			this._emit("var js = { global: function () { return this; }() };\n", null);
 			return;
 		}
+		// bind native object to JSX class
+		if (classDef.getNativeSource() != null) {
+			this._emit("var " + this._namer.getNameOfClass(classDef) + " = " + Util.decodeStringLiteral(classDef.getNativeSource().getValue()) + ";\n", classDef.getNativeSource());
+		}
+
 		if ((classDef.flags() & ClassDefinition.IS_NATIVE) != 0)
 			return;
 		// normal handling
@@ -3084,7 +3089,7 @@ class JavaScriptEmitter implements Emitter {
 				++i;
 		}
 		// start emitting
-		this._emit("var $__jsx_classMap = {", null);
+		this._emit("\n" + "var $__jsx_classMap = {", null);
 		var isFirstEntry = true;
 		while (classDefs.length != 0) {
 			// fetch the first classDef, and others that came from the same file

--- a/t/run/273.native-require-commonjs.jsx
+++ b/t/run/273.native-require-commonjs.jsx
@@ -1,0 +1,24 @@
+/*EXPECTED
+true
+Hello, world!
+*/
+// issue #152
+
+// with double-quoted
+native("require('string_decoder').StringDecoder") class StringDecoder {
+	function constructor(encodingName : string);
+}
+
+// with single-quoted
+native('require("util")') class util {
+	static function format(format : string, ...args : variant) : string;
+}
+
+class _Main {
+	static function main(args : string[]) : void {
+		var sd = new StringDecoder('utf8');
+		log sd instanceof StringDecoder;
+
+		log util.format("Hello, %s!", "world");
+	}
+}


### PR DESCRIPTION
First implementation of #152.

Note that this feature supports neither lazy loading nor load error handling, while the current JSX compiler loads JS modules (source-map and esmangle) dynamically. Should we support such features?

FYI, if I load esprima, esmangle, escodegen and source-map first, it takes 60 ms. on my MacBook Air.
