### PR TITLE
Add parameter variations to JSON.stringify

### DIFF
--- a/lib/built-in.jsx
+++ b/lib/built-in.jsx
@@ -1037,8 +1037,7 @@ native final class JSON {
 	static function stringify(value : variant) : string;
 	static function stringify(value : variant, replacer : function(key:string,value:variant):variant) : string;
 	static function stringify(value : variant, replacer : function(key:string,value:variant):variant, space : number) : string;
-	static function stringify(value : variant, replacer : Nullable.<function(key:string,value:variant):variant>, space : number) : string;
-	static function stringify(value : variant, replacer : Nullable.<function(key:string,value:variant):variant>, space : string) : string;
+	static function stringify(value : variant, replacer : function(key:string,value:variant):variant, space : string) : string;
 }
 
 /**


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify?redirectlocale=en-US&redirectslug=JavaScript%2FReference%2FGlobal_Objects%2FJSON%2Fstringify

JSON.stringify can accept null as a replacer parameter and string as a spacer. This patch adds support of them.
