### PR TITLE
fix the precedence of comma in lambda expression

### DIFF
--- a/src/parser.jsx
+++ b/src/parser.jsx
@@ -3058,7 +3058,7 @@ class Parser {
 			var lastToken : Token;
 			if (! withBlock) {
 				lastToken = null;
-				var expr = this._expr();
+				var expr = this._assignExpr();
 				this._statements.push(new ReturnStatement(token, expr));
 			} else {
 				var lastToken = this._block();

--- a/t/run/307.comma-in-lambda.jsx
+++ b/t/run/307.comma-in-lambda.jsx
@@ -1,0 +1,17 @@
+/*EXPECTED
+10
+20
+30
+*/
+class _Main {
+	static function main (args : string[]) : void {
+		var lambdas = {
+			"foo" : () -> 10,
+			"bar" : () -> (0, 20),
+			"baz" : () -> 30
+		};
+		log lambdas["foo"]();
+		log lambdas["bar"]();
+		log lambdas["baz"]();
+	}
+}


### PR DESCRIPTION
Fixed a bug that the parser interpretes `{ "foo" : () -> 10, "bar" : () -> 20 }` as `{ "foo" : () -> (10, "bar") : () -> 20 }`.
