### PR TITLE
add --enable-release-vars to release variables not captured in closures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ test-all: test test-optimized
 test-debug: test-core test-misc-core
 
 test-optimized:
-	JSX_OPTS="--optimize release --disable-optimize no-log,no-assert" $(MAKE) test-core
+	JSX_OPTS="--optimize release --enable-release-vars --disable-optimize no-log,no-assert" $(MAKE) test-core
 
 test-optimized-minified:
 	JSX_OPTS="--optimize release --disable-optimize no-log,no-assert --minify" $(MAKE) test-core

--- a/node_example/memory-usage-with-closures.jsx
+++ b/node_example/memory-usage-with-closures.jsx
@@ -1,0 +1,65 @@
+/***
+ * A JSX application which scales memory usage on --disable-release-unbound-vars
+ */
+
+import "console.jsx";
+import "js/nodejs.jsx";
+
+class LargeObject {
+  static const A = "abcdefghijklmnopqrstuvwxyz"
+    +"abcdefghijklmnopqrstuvwxyz" +"abcdefghijklmnopqrstuvwxyz"
+    +"abcdefghijklmnopqrstuvwxyz" +"abcdefghijklmnopqrstuvwxyz"
+    +"abcdefghijklmnopqrstuvwxyz" +"abcdefghijklmnopqrstuvwxyz"
+    +"abcdefghijklmnopqrstuvwxyz" +"abcdefghijklmnopqrstuvwxyz"
+    +"abcdefghijklmnopqrstuvwxyz" +"abcdefghijklmnopqrstuvwxyz"
+    +"abcdefghijklmnopqrstuvwxyz" +"abcdefghijklmnopqrstuvwxyz";
+  var a0 = LargeObject.A.split("");
+  var a1 = LargeObject.A.split("");
+  var a2 = LargeObject.A.split("");
+  var a3 = LargeObject.A.split("");
+  var a4 = LargeObject.A.split("");
+}
+
+class _Main {
+  static function reportRSS() : void {
+    var usage = Math.round((process.memoryUsage().rss) / (1024 * 1024));
+    var bar = "";
+    for (var i = 0; i < usage; i += 3) {
+      bar += "*";
+    }
+    var s = usage as string;
+    while (s.length < 3) {
+      s = " " + s;
+    }
+    console.log(s + " MiB" + bar);
+  }
+
+  static function main(args : string[]) : void {
+    _Main.reportRSS();
+
+    var t0 = Date.now();
+
+    var q = new Array.<()->void>;
+
+    for (var i = 0; i < 10; ++i) {
+      (function tick() : void {
+        var now = Date.now();
+
+        var largeObjects = new LargeObject[];
+        for (var i = 0; i < 1000; ++i) {
+          largeObjects.push(new LargeObject);
+        }
+
+        q.push(() -> {
+          console.log(now);
+          //console.log(largeObjects); // capture large objects
+        });
+
+        _Main.reportRSS();
+      }());
+    }
+  }
+}
+
+// vim: set tabstop=2 shiftwidth=2 expandtab:
+

--- a/src/jsx-command.jsx
+++ b/src/jsx-command.jsx
@@ -57,6 +57,7 @@ class JSXCommand {
 			"  --optimize cmd1,cmd2,...   enables optimization commands\n" +
 			"  --warn type1,type2,...     enables warnings (all, experimental, deprecated, none)\n" +
 			"  --disable-type-check       disables run-time type checking\n" +
+			"  --enable-release-vars      releases vars in order not to be captured in closures" +
 			"  --minify                   compresses the target JavaScript code\n" +
 			"  --enable-source-map        enables source map debugging info\n" +
 			"  --complete line:column     shows code completion at line:column\n" +
@@ -320,6 +321,13 @@ class JSXCommand {
 						tasks.push(function (mode : boolean) : () -> void {
 							return function () {
 								emitter.setEnableSourceMap(mode);
+							};
+						}(mode));
+						break NEXTOPT;
+					case "release-vars":
+						tasks.push(function (mode : boolean) : () -> void {
+							return function () {
+								(emitter as JavaScriptEmitter).setEnableReleaseVars(mode);
 							};
 						}(mode));
 						break NEXTOPT;

--- a/src/util.jsx
+++ b/src/util.jsx
@@ -260,6 +260,37 @@ class Util {
 		return true;
 	}
 
+	static function forEachLocalVariableInRHS(funcDef : MemberFunctionDefinition, cb : function(:MemberFunctionDefinition, :LocalVariable) : boolean) : boolean {
+		return funcDef.forEachStatement(function onStatement(statement : Statement) : boolean {
+			if (statement instanceof FunctionStatement) {
+				var prevFuncDef = funcDef;
+				funcDef = (statement as FunctionStatement).getFuncDef();
+				funcDef.forEachStatement(onStatement);
+				funcDef = prevFuncDef;
+			}
+			statement.forEachExpression(function onExpr(expr : Expression) : boolean {
+				if (expr instanceof AssignmentExpression
+				    && (expr as AssignmentExpression).getFirstExpr() instanceof LocalExpression
+					&& (expr as AssignmentExpression).getFirstExpr().getType().equals((expr as AssignmentExpression).getSecondExpr().getType())
+				) {
+					// skip lhs of assignment to local that has no effect
+					return onExpr((expr as AssignmentExpression).getSecondExpr());
+				} else if (expr instanceof LocalExpression) {
+					if (! cb(funcDef, (expr as LocalExpression).getLocal())) {
+						return false;
+					}
+				} else if (expr instanceof FunctionExpression) {
+					var prevFuncDef = funcDef;
+					funcDef = (expr as FunctionExpression).getFuncDef();
+					funcDef.forEachStatement(onStatement);
+					funcDef = prevFuncDef;
+				}
+				return expr.forEachExpression(onExpr);
+			});
+			return statement.forEachStatement(onStatement);
+		});
+	}
+
 	static function findFunctionInClass (classDef : ClassDefinition, funcName : string, argTypes : Type[], isStatic : boolean) : MemberFunctionDefinition {
 		var found = null : MemberFunctionDefinition;
 		classDef.forEachMemberFunction(function (funcDef) {

--- a/t/optimize/091.release-unbound-vars.jsx
+++ b/t/optimize/091.release-unbound-vars.jsx
@@ -1,0 +1,47 @@
+/*EXPECTED
+foo
+bar
+true
+*/
+/*JSX_OPTS
+--enable-release-vars
+*/
+
+class EventEmitter {
+  var _listeners = new Array.<() -> void>;
+
+  function addEventListener(listener : () -> void) : void {
+    this._listeners.push(listener);
+  }
+
+  function hasListeners() : boolean {
+    return this._listeners.length != 0;
+  }
+}
+
+
+class _Main {
+  static function f() : EventEmitter {
+    var foo = "foo";
+    var bar = "bar";
+
+    log foo;
+    log bar;
+
+    var o = new EventEmitter;
+    o.addEventListener(() -> {
+      var z = 42;
+      log foo;
+      log z;
+    });
+    // XXX: bar should be released here
+    return o;
+  }
+
+
+  static function main(args : string[]) : void {
+    var o = _Main.f();
+    log o.hasListeners();
+  }
+}
+// vim: set expandtab tabstop=2 shiftwidth=2 ft=jsx:

--- a/t/optimize/092.release-unbound-vars-complex.jsx
+++ b/t/optimize/092.release-unbound-vars-complex.jsx
@@ -1,0 +1,55 @@
+/*EXPECTED
+foo
+bar
+true
+*/
+/*JSX_OPTS
+--enable-release-vars
+*/
+
+
+class EventEmitter {
+  var _listeners = new Array.<() -> void>;
+
+  function addEventListener(listener : () -> void) : void {
+    this._listeners.push(listener);
+  }
+
+  function hasListeners() : boolean {
+    return this._listeners.length != 0;
+  }
+}
+
+
+class _Main {
+  static function f() : EventEmitter {
+    return (function () : EventEmitter {
+      var foo = "foo";
+      var bar = "bar";
+
+      log foo;
+      log bar;
+
+      var o = new EventEmitter;
+      o.addEventListener(() -> {
+        try {
+          var z = 42;
+          log z == 0 ? "zzz" : foo;
+          log z;
+        }
+        finally {
+          z = 0;
+        }
+      });
+      // XXX: bar should be released here
+      return o;
+    }());
+  }
+
+
+  static function main(args : string[]) : void {
+    var o = _Main.f();
+    log o.hasListeners();
+  }
+}
+// vim: set expandtab tabstop=2 shiftwidth=2 ft=jsx:


### PR DESCRIPTION
Added an optional feature to release variables; however, it might not be worth merging if major JS environments have this feature; at least the latest V8 and JavaScriptCore has the exactly same feature. What do you think of it?
### Description of the memory benchmark program

See node_example/node_example/memory-usage-with-closures.jsx which reports memory usage for environment capturing in closures.

https://github.com/jsx/JSX/blob/gfx/release-unbound-vars/node_example/memory-usage-with-closures.jsx

showing a report like this:

```
$ jsx --run --enable-release-vars node_example/memory-usage-with-closures.jsx
 42 MiB**************
 56 MiB*******************
 63 MiB*********************
 77 MiB**************************
 90 MiB******************************
103 MiB***********************************
 62 MiB*********************
 76 MiB**************************
 89 MiB******************************
 60 MiB********************
```

which is completely the same as the case with --disable-release-vars.

Note that the benchmark itself looks correct because if you capture the variable storing large objects then the GC doesn't release objects as expected. See the following patch and report.

``` patch
diff --git a/node_example/memory-usage-with-closures.jsx b/node_example/memory-usage-with-closures.jsx
index 04281fe..7f7c72c 100644
--- a/node_example/memory-usage-with-closures.jsx
+++ b/node_example/memory-usage-with-closures.jsx
@@ -52,7 +52,7 @@ function tick() : void {

         q.push(() -> {
           console.log(now);
-          //console.log(largeObjects); // capture large objects
+          console.log(largeObjects); // capture large objects
         });

         _Main.reportRSS();
```

then the result:

```
jsx --run --enable-release-vars node_example/memory-usage-with-closures.jsx
 42 MiB**************
 55 MiB*******************
 63 MiB*********************
 76 MiB**************************
 90 MiB******************************
103 MiB***********************************
116 MiB***************************************
130 MiB********************************************
143 MiB************************************************
157 MiB*****************************************************
170 MiB*********************************************************
```
