### PR TITLE
--optimize takes disabler operands (startin with "-")

### DIFF
--- a/src/jsx-command.jsx
+++ b/src/jsx-command.jsx
@@ -189,11 +189,18 @@ class JSXCommand {
 				if ((optarg = getoptarg()) == null) {
 					return 1;
 				}
-				if (optarg == "release") {
-					optimizeCommands = Optimizer.getReleaseOptimizationCommands();
-				} else {
-					optimizeCommands = optimizeCommands.concat(optarg.split(","));
-				}
+				optarg.split(",").forEach((command) -> {
+					if (command == "release") {
+						optimizeCommands = Optimizer.getReleaseOptimizationCommands();
+					} else if (command.charAt(0) == "-") {
+						command = command.slice(1);
+						optimizeCommands = optimizeCommands.filter((item) -> {
+							return command != item;
+						});
+					} else {
+						optimizeCommands.push(command);
+					}
+				});
 				break;
 			case "--disable-optimize":
 				if ((optarg = getoptarg()) == null) {


### PR DESCRIPTION
`$ jsx --optimize release --disable-optimize no-log,no-assert foo.jsx`
is now deprecated, instead the preferred style is
`$ jsx --optimize release,-no-log,-no-assert foo.jsx`
