### PR TITLE
fix error when compile jsx code with absolute path on Windows

### DIFF
--- a/src/jsx-node-front.jsx
+++ b/src/jsx-node-front.jsx
@@ -57,7 +57,7 @@ class NodePlatform extends Platform {
 	}
 
 	function _absPath(path : string) : string {
-		return (path.charAt(0) == "/" || path.match(/^[a-zA-Z]:\//))
+		return (path.charAt(0) == "/" || path.match(/^[a-zA-Z]:[\/\\]/))
 			? path // path is already absolute
 			: this._cwd + "/" + path;
 	}


### PR DESCRIPTION
`NodePlatform.save()` method receives `outputPath` as backslash separated path string. This method(`_absPath`) returns invalid path when it processes backslash separated path string.
