### PR TITLE
Autolift generator return types

### DIFF
--- a/src/expression.jsx
+++ b/src/expression.jsx
@@ -917,6 +917,20 @@ class FunctionExpression extends Expression {
 			context.errors.push(new CompileError(this._token, "argument types were not automatically deductable, please specify them by hand"));
 			return false;
 		}
+		var returnType = this._funcDef.getReturnType();
+		if (this._funcDef.isGenerator()) {
+			if (returnType == null) {
+				context.errors.push(new CompileError(this._token, "return type was not automatically deductable, please specify them by hand"));
+				return false;
+			} else {
+				var classDef;
+				if (! (returnType instanceof ObjectType
+					&& (classDef = returnType.getClassDef()) instanceof InstantiatedClassDefinition
+					&& (classDef as InstantiatedClassDefinition).getTemplateClassName() == "Generator")) {
+						this._funcDef.setReturnType(new ObjectType(Util.instantiateTemplate(context, this._token, "Generator", [ Type.voidType, returnType ])));
+				}
+			}
+		}
 		this._funcDef.analyze(context);
 		return true; // return true since everything is resolved correctly even if analysis of the function definition failed
 	}

--- a/src/statement.jsx
+++ b/src/statement.jsx
@@ -281,6 +281,15 @@ class FunctionStatement extends Statement {
 			context.errors.push(new CompileError(this._token, "argument / return types were not automatically deductable, please specify them by hand"));
 			return false;
 		}
+		var returnType = this._funcDef.getReturnType();
+		if (this._funcDef.isGenerator()) {
+			var classDef;
+			if (! (returnType instanceof ObjectType
+				&& (classDef = returnType.getClassDef()) instanceof InstantiatedClassDefinition
+				&& (classDef as InstantiatedClassDefinition).getTemplateClassName() == "Generator")) {
+					this._funcDef.setReturnType(new ObjectType(Util.instantiateTemplate(context, this._token, "Generator", [ Type.voidType, returnType ])));
+			}
+		}
 		this._funcDef.analyze(context);
 		// the function can be used from the scope of the same level
 		context.getTopBlock().localVariableStatuses.setStatus(this._funcDef.getFuncLocal());

--- a/t/run/generator.023.autolift-generator-type.jsx
+++ b/t/run/generator.023.autolift-generator-type.jsx
@@ -6,14 +6,14 @@
 class _Main {
 	static function main (args : string[]) : void {
 
-		// Instead of `Generator.<int>`, just writing `int` at the place of return type.
+		// Instead of `Generator.<void,int>`, just writing `int` at the place of return type.
 		function * foo () : int {
 			var c = 0;
 			while (true)
 				yield c++;
 		}
 
-		var gen : Generator.<int> = foo();
+		var gen : Generator.<void,int> = foo();
 
 		log gen.next().value;
 		log gen.next().value;


### PR DESCRIPTION
Add generator return type autolifting. You are no longer required to write redundant `void yield` when use generators as output only stream (i.e. use yield expression as a statement), only writing the type you want to return from `.next()` method by `yield` is now alright.

```
function * g () : int {
  while (true) {
    yield 1;
  }
}
```
