### PR TITLE
default parameter with other param

### DIFF
--- a/src/parser.jsx
+++ b/src/parser.jsx
@@ -3447,14 +3447,17 @@ class Parser {
 				var assignToken = this._expectOpt("=");
 				if (assignToken != null)  {
 					var state = this._preserveState();
+					this._pushScope(null, args);
 					try {
 						if ((defaultValue = this._assignExpr(true)) == null) {
 							return null;
 						}
 					} finally {
 						// do not create a between the parent method and the children funcDefs stored in defVal
-						if (this._closures != null)
+						if (this._closures != null) {
 							this._closures.splice(state.numClosures, this._closures.length - state.numClosures);
+						}
+						this._popScope();
 					}
 					if (! allowDefaultValues) {
 						this._errors.push(new CompileError(assignToken, "default parameters are only allowed for member functions"));

--- a/t/run/397.default-param-with-other-param.jsx
+++ b/t/run/397.default-param-with-other-param.jsx
@@ -1,0 +1,21 @@
+/*EXPECTED
+f
+1
+43
+f
+10
+20
+*/
+class _Main {
+  static function f(a : number, b : number = a + 42) : void {
+    log "f";
+    log a;
+    log b;
+  }
+
+  static function main(args : string[]) : void {
+    _Main.f(1);
+    _Main.f(10, 20);
+  }
+}
+// vim: set expandtab tabstop=2 shiftwidth=2 ft=jsx:


### PR DESCRIPTION
This code fails to compile.

```
class _Main {
    static function fn(a : number, b : number = a * 2) : number {
        return a + b;
    }

    static function main(args : string[]) : void {
        log _Main.fn(5);
    }
}
```

```
ERROR!
[input:2:48] could not find definition for template class: 'a'
    static function fn(a : number, b : number = a * 2) : number {
                                                ^
[input:2:48] no class definition or variable for 'a'
    static function fn(a : number, b : number = a * 2) : number {
                                                ^
```

In ECMAScript6 of Firefox, allow default parameters to be initialized with other parameter value.
How do you feel about that?
