### PR TITLE
Do not expand FusedAssignmentExpression by _InlineOptimizeCommand

### DIFF
--- a/src/optimizer.jsx
+++ b/src/optimizer.jsx
@@ -2766,6 +2766,11 @@ class _InlineOptimizeCommand extends _FunctionOptimizeCommand implements _Struct
 					if (assignExpr.getFirstExpr() instanceof LocalExpression) {
 						updateCountOfLocal((assignExpr.getFirstExpr() as LocalExpression).getLocal(), -Infinity);
 					}
+				} else if (expr instanceof FusedAssignmentExpression) {
+					var fusedAssignExpr = expr as FusedAssignmentExpression;
+					if (fusedAssignExpr.getFirstExpr() instanceof LocalExpression) {
+						updateCountOfLocal((fusedAssignExpr.getFirstExpr() as LocalExpression).getLocal(), -Infinity);
+					}
 				} else if (expr instanceof IncrementExpression) {
 					var incrExpr = expr as IncrementExpression;
 					if (incrExpr.getExpr() instanceof LocalExpression) {

--- a/t/run/399.not-expand-FusedAssignmentExpression.jsx
+++ b/t/run/399.not-expand-FusedAssignmentExpression.jsx
@@ -1,0 +1,17 @@
+/*EXPECTED
+3
+*/
+/*JSX_OPTS
+--optimize inline
+*/
+class _Main {
+
+    static function fn(a : number) : void {
+        a += 2;
+        log a;
+    }
+
+    static function main(args : string[]) : void {
+        _Main.fn(1);
+    }
+}


### PR DESCRIPTION
This code is compile error same as #328.

``` js
import "console.jsx";

class _Main {

    static function fn(a : number) : void {
        a += 2;
        console.log(a);
    }

    static function main(args : string[]) : void {
        _Main.fn(1);
    }
}
```

Do not expand FusedAssignmentExpression in the same way as AssignmentExpression and IncrementExpression.
