### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
   },
   "dependencies": {
     "source-map": "~ 0.1.22",
-    "esprima": "~ 1.0.2",
-    "escodegen": "~ 0.0.20",
-    "esmangle": "~ 0.0.14",
+    "esprima": "~ 1.1.0",
+    "escodegen": "1.3.3",
+    "esmangle": "~ 1.0.0",
     "source-map-support": "~ 0.2.1"
   },
   "engines": {


### PR DESCRIPTION
Note: escodegen 1.3.4 requires node v0.10.x.
